### PR TITLE
Define `open_pickle` in `pickle_api.py`

### DIFF
--- a/wikiwho_wrapper/pickle_api.py
+++ b/wikiwho_wrapper/pickle_api.py
@@ -4,7 +4,11 @@ from typing import Union
 import numpy as np
 import deprecation
 
-from wikiwho import open_pickle
+from os.path import join
+import pickle
+def open_pickle(article_id, pickle_path='pickles', lang=''):
+    with open(join(pickle_path, lang, f'{article_id}.p'), 'rb') as _f:
+        return pickle.load(_f)
 
 from . import __version__
 from .api import WikiWhoAPI


### PR DESCRIPTION
The import statement causes an error (since there is no module `wikiwho` to import `open_pickle` from).  Simply defining it in place should fix the issue.  As noted in https://github.com/gesiscss/wikiwho_wrapper/issues/3